### PR TITLE
Fix headers already sent error when exchanging code for token fails

### DIFF
--- a/routes/authorize.js
+++ b/routes/authorize.js
@@ -10,16 +10,13 @@ router.get('/', async function(req, res, next) {
 
   // If code is present, use it
   if (code) {
-    let token;
-
     try {
-      token = await authHelper.getTokenFromCode(code, res);
+      await authHelper.getTokenFromCode(code, res);
+      // Redirect to home
+      res.redirect('/');
     } catch (error) {
       res.render('error', { title: 'Error', message: 'Error exchanging code for token', error: error });
     }
-
-    // Redirect to home
-    res.redirect('/');
   } else {
     // Otherwise complain
     res.render('error', { title: 'Error', message: 'Authorization error', error: { status: 'Missing code parameter' } });


### PR DESCRIPTION
First of all thanks for the great tutorial. Really helped to quickly setup an integration with the Outlook Calendar! After deploying it however, I couldn't log in and the app didn't show me an error. The express server did and showed an error about headers already being sent. This fixed that for me and showed me the actual error in the app.